### PR TITLE
Es node gc time

### DIFF
--- a/elasticsearch_node_status/elasticsearch_node_status.rb
+++ b/elasticsearch_node_status/elasticsearch_node_status.rb
@@ -100,7 +100,7 @@ class ElasticsearchClusterNodeStatus < Scout::Plugin
     bytes && bytes.to_f / 1024 / 1024
   end
 
-  # Reports the time spent in collection / # of collections for this reporting period for ES < 1.0.
+  # Reports the time spent in collection / # of collections for this reporting period.
   def gc_time(data)
     key = data.keys.first.to_s
     collection_time = data.values.first['collection_time_in_millis'] || 0

--- a/elasticsearch_node_status/elasticsearch_node_status.rb
+++ b/elasticsearch_node_status/elasticsearch_node_status.rb
@@ -62,7 +62,13 @@ class ElasticsearchClusterNodeStatus < Scout::Plugin
     report(:non_heap_committed => b_to_mb(response['jvm']['mem']['non_heap_committed_in_bytes'] || 0))
     report(:threads_count => response['jvm']['threads']['count'] || 0)
 
-    gc_time(:gc_collection_time => response['jvm']['gc'])
+    # ES >= 1.0
+    gc_time(:gc_young_collection_time => response['jvm']['gc']['collectors']['young']) if response['jvm']['gc']['collectors']['young']
+    gc_time(:gc_old_collection_time => response['jvm']['gc']['collectors']['old']) if response['jvm']['gc']['collectors']['old']
+    gc_time(:gc_survivor_collection_time => response['jvm']['gc']['collectors']['survivor']) if response['jvm']['gc']['collectors']['survivor']
+
+    # ES < 1.0
+    gc_time(:gc_collection_time => response['jvm']['gc']) if response['jvm']['gc']['collection_count']
     # Additional GC metrics provided by ElasticSearch can vary:
     gc_time(:gc_parnew_collection_time => response['jvm']['gc']['collectors']['ParNew']) if response['jvm']['gc']['collectors']['ParNew']
     gc_time(:gc_cms_collection_time => response['jvm']['gc']['collectors']['ConcurrentMarkSweep']) if response['jvm']['gc']['collectors']['ConcurrentMarkSweep']
@@ -94,7 +100,7 @@ class ElasticsearchClusterNodeStatus < Scout::Plugin
     bytes && bytes.to_f / 1024 / 1024
   end
 
-  # Reports the time spent in collection / # of collections for this reporting period.
+  # Reports the time spent in collection / # of collections for this reporting period for ES < 1.0.
   def gc_time(data)
     key = data.keys.first.to_s
     collection_time = data.values.first['collection_time_in_millis'] || 0

--- a/elasticsearch_node_status/elasticsearch_node_status.yml
+++ b/elasticsearch_node_status/elasticsearch_node_status.yml
@@ -40,3 +40,15 @@ metadata:
     label: GC - ConcurrentMarkSweep
     units: ms
     precision: "0"
+  gc_young_collection_time:
+    label: GC - Young
+    units: ms
+    precision: "0"
+  gc_old_collection_time:
+    label: GC - Old
+    units: ms
+    precision: "0"
+  gc_survivor_collection_time:
+    label: GC - Survivor
+    units: ms
+    precision: "0"


### PR DESCRIPTION
Looks like https://github.com/elasticsearch/elasticsearch/issues/4661 mentions a breaking change w/how GC pools are named. 

This adds support for reporting those pools. Note that it looks like `total` is no longer available.