### PR TITLE
Allow the plugin to read a default file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 # plugin-specific
 gem 'pg'
-gem 'mysql'
+gem 'mysql2'
 gem 'mongo'
 gem 'request-log-analyzer'
 gem 'beanstalk-client'

--- a/mysql_replication_monitor/test.rb
+++ b/mysql_replication_monitor/test.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../../test_helper.rb', __FILE__)
 require File.expand_path('../mysql_replication_monitor.rb', __FILE__)
 
-require 'mysql'
+require 'mysql2'
 
 class MysqlReplicationMonitorTest < Test::Unit::TestCase
 
@@ -14,9 +14,11 @@ class MysqlReplicationMonitorTest < Test::Unit::TestCase
     # @plugin=PluginName.new(last_run, memory, options)
     #                        date      hash    hash
     @plugin = MysqlReplicationMonitor.new(nil, {}, @options)
-    ms_res = Mysql::Result.new
-    ms_res.stubs(:fetch_hash).returns(FIXTURES[:success])
-    Mysql.any_instance.stubs(:query).with("show slave status").returns(ms_res).once
+    ms_res = Mysql2::Result.new
+    ms_res.stubs(:all).returns([FIXTURES[:success]])
+    puts ms_res.each {|r| puts r}
+    puts FIXTURES[:success]
+    Mysql2::Client.any_instance.stubs(:query).with("show slave status").returns(ms_res).once
     res = @plugin.run()
 
     # assertions
@@ -25,9 +27,9 @@ class MysqlReplicationMonitorTest < Test::Unit::TestCase
 
   def test_replication_not_configured
     @plugin = MysqlReplicationMonitor.new(nil, {}, @options)
-    ms_res = Mysql::Result.new
-    ms_res.stubs(:fetch_hash).returns(nil)
-    Mysql.any_instance.stubs(:query).with("show slave status").returns(ms_res).once
+    ms_res = Mysql2::Result.new
+    ms_res.stubs(:query).returns(nil)
+    Mysql2::Client.any_instance.stubs(:query).with("show slave status").returns(ms_res).once
     res= @plugin.run()
 
     # assertions
@@ -36,9 +38,9 @@ class MysqlReplicationMonitorTest < Test::Unit::TestCase
 
   def test_replication_failure
     @plugin = MysqlReplicationMonitor.new(nil, {}, @options)
-    ms_res = Mysql::Result.new
-    ms_res.stubs(:fetch_hash).returns(FIXTURES[:failure])
-    Mysql.any_instance.stubs(:query).with("show slave status").returns(ms_res).once
+    ms_res = Mysql2::Result.new
+    ms_res.stubs(:query).returns(FIXTURES[:failure])
+    Mysql2::Client.any_instance.stubs(:query).with("show slave status").returns(ms_res).once
     res = @plugin.run()
 
     # assertions
@@ -48,9 +50,9 @@ class MysqlReplicationMonitorTest < Test::Unit::TestCase
 
   def test_replication_failure_nil_seconds_behind
     @plugin = MysqlReplicationMonitor.new(nil, {}, @options)
-    ms_res = Mysql::Result.new
-    ms_res.stubs(:fetch_hash).returns(FIXTURES[:failure_nil_seconds_behind])
-    Mysql.any_instance.stubs(:query).with("show slave status").returns(ms_res).once
+    ms_res = Mysql2::Result.new
+    ms_res.stubs(:query).returns(FIXTURES[:failure_nil_seconds_behind])
+    Mysql2::Client.any_instance.stubs(:query).with("show slave status").returns(ms_res).once
     res = @plugin.run()
 
     # assertions


### PR DESCRIPTION
Reading a default file for options allows for CM to deploy a custom
password for the system to scout.

This changed required using a newer supported library, upgrading
from mysql to mysql2 gem.

Unit tests aren't passing, it doesn't appear the mysql2 gem supports
stubbing, and trying to call the count method without having a real
database handle causes it to segfault. This only impacts test not
real usage.

This was reported upstream:
https://github.com/brianmario/mysql2/issues/610