### PR TITLE
Override server discovery for mongo_server_status

### DIFF
--- a/mongo_server_status/mongo_server_status.rb
+++ b/mongo_server_status/mongo_server_status.rb
@@ -77,7 +77,7 @@ class MongoServerStatus < Scout::Plugin
   end
 
   def get_server_status_v2
-    client = Mongo::Client.new(["#{@host}:#{@port}"], :database => 'admin', :ssl => @ssl, :connection_timeout => @connect_timeout, :socket_timeout => @op_timeout, :server_selection_timeout => 1)
+    client = Mongo::Client.new(["#{@host}:#{@port}"], :database => 'admin', :ssl => @ssl, :connection_timeout => @connect_timeout, :socket_timeout => @op_timeout, :server_selection_timeout => 1, :connect => :direct)
     client = client.with(user: @username, password: @password) unless @username.nil?
     stats = client.database.command(:serverStatus => 1).first
     get_server_status(stats)


### PR DESCRIPTION
Otherwise, in replicasets with low latency, the plugin extracts
statistics only from the Primary of the replicaSet.

Fixes scoutapp/scout-plugins#212 .