### PR TITLE
Add dns resolver

### DIFF
--- a/name_resolution/name_resolver.rb
+++ b/name_resolution/name_resolver.rb
@@ -1,6 +1,5 @@
-require 'resolv'
-
 class NameResolver < Scout::Plugin
+  needs 'resolv'
   OPTIONS=<<-EOS
     nameserver:
       default: 8.8.8.8
@@ -12,9 +11,11 @@ class NameResolver < Scout::Plugin
     resolver = Resolv::DNS.new(:nameserver => [option(:nameserver)])
 
     begin
-      result = resolver.getaddress(option(:resolve_address))
-    rescue Resolv::ResolvError => err
-      alert('Failed to resolve', err)
+      resolver.getaddress(option(:resolve_address))
+    rescue Resolv::ResolvError, Resolv::ResolvTimeout => err
+      report(:resolved? => 0, :result => err)
+    else
+      report(:resolved? => 1)
     end
   end
 end

--- a/name_resolution/name_resolver.rb
+++ b/name_resolution/name_resolver.rb
@@ -1,0 +1,21 @@
+require 'resolv'
+
+class NameResolver < Scout::Plugin
+  OPTIONS=<<-EOS
+    nameserver:
+      default: 8.8.8.8
+    resolve_address:
+      default: google.com
+  EOS
+
+  def build_report
+    resolver = Resolv::DNS.new(:nameserver => [option(:nameserver)])
+
+    begin
+      result = resolver.getaddress(option(:resolve_address))
+    rescue Resolv::ResolvError => err
+      alert('Failed to resolve', err)
+    end
+  end
+end
+

--- a/name_resolution/name_resolver.rb
+++ b/name_resolution/name_resolver.rb
@@ -8,21 +8,15 @@ class NameResolver < Scout::Plugin
     timeout:
       default: 30
   EOS
-  # Doesn't work :(
-  TIMEOUT=77
 
   def build_report
-    resolver = Resolv::DNS.new(:nameserver => [option(:nameserver)])
-
-    # Only Ruby >= 2.0.0 supports setting a timeout.
-    # Without this DNS timeouts will raise a PluginTimeoutError
-    if resolver.respond_to? :timeouts=
-      resolver.timeouts = option(:timeout)
-    end
-
     begin
-      resolver.getaddress(option(:resolve_address))
-    rescue Resolv::ResolvError, Resolv::ResolvTimeout => err
+      # Only Ruby >= 2.0.0 supports setting a timeout, so use this
+      Timeout.timeout(option(:timeout)) do
+        resolver = Resolv::DNS.new(:nameserver => [option(:nameserver)])
+        resolver.getaddress(option(:resolve_address))
+      end
+    rescue Resolv::ResolvError, Resolv::ResolvTimeout, Timeout::Error => err
       report(:resolved? => 0, :result => err)
     else
       report(:resolved? => 1)

--- a/name_resolution/name_resolver.rb
+++ b/name_resolution/name_resolver.rb
@@ -5,10 +5,20 @@ class NameResolver < Scout::Plugin
       default: 8.8.8.8
     resolve_address:
       default: google.com
+    timeout:
+      default: 30
   EOS
+  # Doesn't work :(
+  TIMEOUT=77
 
   def build_report
     resolver = Resolv::DNS.new(:nameserver => [option(:nameserver)])
+
+    # Only Ruby >= 2.0.0 supports setting a timeout.
+    # Without this DNS timeouts will raise a PluginTimeoutError
+    if resolver.respond_to? :timeouts=
+      resolver.timeouts = option(:timeout)
+    end
 
     begin
       resolver.getaddress(option(:resolve_address))

--- a/name_resolution/name_resolver.rb
+++ b/name_resolution/name_resolver.rb
@@ -12,7 +12,7 @@ class NameResolver < Scout::Plugin
   def build_report
     begin
       # Only Ruby >= 2.0.0 supports setting a timeout, so use this
-      Timeout.timeout(option(:timeout)) do
+      Timeout.timeout(option(:timeout).to_i) do
         resolver = Resolv::DNS.new(:nameserver => [option(:nameserver)])
         resolver.getaddress(option(:resolve_address))
       end


### PR DESCRIPTION
This plugin allows monitoring of DNS requests and reports on their success/failure.