### PR TITLE
Fixing MongoDB Database Stats to use correct version checking

### DIFF
--- a/mongo_database_stats/mongo_database_stats.rb
+++ b/mongo_database_stats/mongo_database_stats.rb
@@ -69,11 +69,9 @@ class MongoDatabaseStats < Scout::Plugin
   end
 
   def get_stats
-    if Mongo::constants.include?(:VERSION)
-      # Mongo gem 2.0 and above have Mongo::VERSION
+    if(Mongo::constants.include?(:VERSION) && Mongo::VERSION.split(':').first.to_i >= 2)
       stats_mongo_v2
     else
-      # Mongo Gem < 2.0 does not have Mongo::VERSION
       stats_mongo_v1
     end
   end


### PR DESCRIPTION
Sometime this year it was updated, but this plugin and the MongoDB Server Status use different version checking and this one was wrong.

Gem version 1.5.2 has the VERSION constant, so the previous check always sets it to the version >2 code.


```bash
[user@server]$ gem list mongo

*** LOCAL GEMS ***

mongo (1.5.2)
mongo_ext (0.19.3)
[user@server]$ irb
irb(main):001:0> require 'mongo'
=> true
irb(main):002:0> Mongo::VERSION
=> "1.5.2"
```