### PR TITLE
Removing HTTPServiceUnvailable from the list of valid responses to determine if the site is up or not.

### DIFF
--- a/url_monitor/url_monitor.rb
+++ b/url_monitor/url_monitor.rb
@@ -87,7 +87,7 @@ class UrlMonitor < Scout::Plugin
   end
 
   def valid_http_response?(result)
-    [HTTPOK,HTTPFound,HTTPServiceUnavailable].include?(result.class)
+    [HTTPOK,HTTPFound].include?(result.class)
   end
 
   # returns the http response from a url


### PR DESCRIPTION
Per HTTP response codes: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html

Although a 503 is temporary, "the client SHOULD handle the response as it would for a 500 response".

Removing HTTPServiceUnvailable from the list of valid responses to determine if the site is up or not.

Requesting this change per support ticket raised earlier today:

==================== Email thread =================
Chris-

On Wednesday, January 13, 2016 at 2:58:16 PM UTC-7, Christopher Schroeder wrote:
Mike,

Yeah, that was another option, set a trigger on the value, but I have quite a few and was hoping to avoid that, as well as remember to to do it on future end points.

Understood. We'll take a look at the plugin. 

Do I have the right project to do the pull request: https://github.com/scoutapp/scout-plugins ?

Yes that is the correct URL for the pull request. 



Cheers,



On Jan 13, 2016, at 4:54 PM, Mike Harrington <mike@scoutapp.com> wrote:

Hi Chris-



On Wednesday, January 13, 2016 at 2:21:34 PM UTC-7, Christopher Schroeder wrote:
Hello,

I know the plugins are open source, so I’m not sure how you handle support. But I just found a site was down that was being monitored by the URL Monitoring plugin written by Eric Lindvall. I use this plugin a lot to monitor various end points, however I found an issue in the code. Rather, what I think is an issue.

When checking for something up or down, it currently does:

  def valid_http_response?(result)
    [HTTPOK,HTTPFound,HTTPServiceUnavailable].include?(result.class)
  end

However, HTTPOK and HTTPFound might be OK, but HTTPServiceUnavailble is not for something checking the status of a URL. For us, our load balancer was returning this and the site was not available. So we were getting false positives when in fact the site was down.

The plugin was actually reporting a 503 code 

https://scoutapp.com/dashboards/share/wJLMHiWEnBncAbt39hjrYA

The solution to this is to set a trigger for the plugin

e.g.  trigger on response code >=500

I know I can always copy the code and modify it within my account, which i”m happy to do. However I thought I would first ask is this really intended to do this, or is it something that could be changed?

I understand this could be a pain for all endpoints of the plugin. Would you be willing to make a pull request on the plugin with your above reasoning? 
 
Cheers,

