### PR TITLE
Fixed two items and added a feature

### DIFF
--- a/mongo_database_stats/mongo_database_stats.rb
+++ b/mongo_database_stats/mongo_database_stats.rb
@@ -9,9 +9,6 @@ class MongoDatabaseStats < Scout::Plugin
     database:
       name: Mongo Database
       notes: Name of the MongoDB database to profile.
-    auth_source:
-      name: Authentication Source
-      notes: Name of the MongoDB database to authenticate the user against (defaults to database if none specified).
     host:
       name: Mongo Server
       notes: Where mongodb is running.
@@ -35,6 +32,10 @@ class MongoDatabaseStats < Scout::Plugin
     op_timeout:
       name: Operation Timeout
       notes: The number of seconds to wait for a read operation to time out. Disabled by default.
+      attributes: advanced
+    auth_source:
+      name: Authentication Source
+      notes: Name of the MongoDB database to authenticate the user against (defaults to database if none specified).
       attributes: advanced
   EOS
 


### PR DESCRIPTION
1. Spelling of retrive fixed in error message.
2. The parameter for authentication is "user" not "username" for mongo ruby driver.

Feature - Added a feature to specify a different authentication source than the database in question.