### PR TITLE
Process usage: alert when the process is not found

### DIFF
--- a/process_usage/process_usage.rb
+++ b/process_usage/process_usage.rb
@@ -94,7 +94,7 @@ class ProcessUsage < Scout::Plugin
       report(:num_processes => 0)
       if alert_when_command_not_found
         unless in_ignore_window?
-          error( "Command not found.", "No processes found matching #{option(:command_name)}." )
+          alert( "Command not found.", "No processes found matching #{option(:command_name)}." )
         end
       end
     end


### PR DESCRIPTION
The process usage plugin currently throws an error when the command is not found, but according to [Scout's own documentation](https://scoutapp.com/info/creating_a_plugin#alerts), this should actually be an alert: 

> You should use errors when something has prevented your plugin from operating properly and the user can do something about it

In this particular case; nothing has prevented the plugin from operating properly: the plugin is attempting to report an error (and that doesn't work because it's throwing an error instead of an alert).