### PR TITLE
Cassandra

### DIFF
--- a/cassandra/cassandra.rb
+++ b/cassandra/cassandra.rb
@@ -1,0 +1,122 @@
+#################################################
+# Cassandra
+#
+#   Report on Cassandra cluster health
+#
+# Created by Matt Chesler 2016-04-20
+#################################################
+
+class Cassandra < Scout::Plugin
+  needs 'csv'
+
+  class BinaryNotFoundError < RuntimeError; end
+  class ConnectionError < RuntimeError; end
+
+  SIZE_SUFFIXES = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+  OPTIONS=<<-EOS
+    nodetool_path:
+      name: Nodetool Path
+      default: /usr/bin/nodetool
+      notes: Path to Cassandra's nodetool
+  EOS
+
+  def build_report
+    data_centers = process_data_centers(parse_output(execute_command))
+
+    report(
+      :total_datacenters => data_centers.size,
+      :total_nodes       => data_centers.collect { |dc| dc[:nodes].size }.reduce(:+),
+      :avg_node_load     => avg_node_load(data_centers),
+      :up_nodes          => nodes_by_status(data_centers, 'UN'),
+      :down_nodes        => nodes_by_status(data_centers, 'DN')
+    )
+  rescue BinaryNotFoundError
+    alert("Cannot find Cassandra nodetool binary")
+  rescue ConnectionError => e
+    alert("Unable to connect to Cassandra", e.message)
+  end
+
+  protected
+  def nodes_by_status(data_centers, status)
+    data_centers.collect{|dc| dc[:nodes].select{|n| n[:status] == status}.size }.reduce :+
+  end
+
+  def avg_node_load(data_centers)
+    loads = data_centers.collect{|dc| dc[:nodes].collect{|n| n[:load] } }.flatten
+    (loads.collect{|l| load_to_number(l) }.reduce(:+) / loads.size).to_i
+  end
+
+  def load_to_number(load)
+    value, suffix = load.match(/(\d+\.\d+) (['A-Z']{2})$/)[1..2]
+    value = value.to_f
+    magnitude = SIZE_SUFFIXES.index(suffix) + 1
+    magnitude.times{ value = value * 1024}
+    value
+  end
+
+  def nodetool_bin
+    raise BinaryNotFoundError unless File.exist?(option(:nodetool_path))
+    @nodetool ||= option(:nodetool_path)
+  end
+
+  def execute_command
+    output = `#{nodetool_bin} status 2>&1`
+    exit_code = $?.to_i
+
+    { :exit_code => exit_code, :output => output }
+  end
+
+  def parse_output(results)
+    if results[:exit_code] != 0
+      raise ConnectionError, results[:output].chomp
+    else
+      data_centers = []
+      current_data_center = nil
+      results[:output].each_line do |line|
+        next if line.strip.empty?
+        case line
+        when /Datacenter\:/
+          current_data_center = {}
+          current_data_center[:name] = line.match(/\: (.+)/)[1]
+          data_centers << current_data_center
+        when /\-\-/
+          current_data_center[:csv] = line
+        end
+        next unless current_data_center && current_data_center[:csv]
+        current_data_center[:csv] << line
+      end
+      return data_centers
+    end
+  end
+
+  def process_data_centers(data_centers)
+    data_centers.each do |data_center|
+      data_center[:nodes] = []
+      csv_string = data_center.delete(:csv)
+      next unless csv_string
+      keys = []
+      csv_string.lines.each do |line|
+        case line
+        when /^--/
+          keys = line.split(/\s{2}+/).collect do |key|
+            case key
+            when /--/
+              :status
+            else
+              key.strip.gsub(' ', '_').downcase.to_sym
+            end
+          end
+        else
+          values = line.split(/\s{2}+/)
+          node_hash = {}
+          keys.each_with_index do |key, i|
+            node_hash[key] = values[i].strip
+          end
+          data_center[:nodes] << node_hash
+        end
+      end
+    end
+    data_centers
+  end
+end

--- a/cassandra/cassandra.rb
+++ b/cassandra/cassandra.rb
@@ -31,8 +31,8 @@ class Cassandra < Scout::Plugin
       :up_nodes          => nodes_by_status(data_centers, 'UN'),
       :down_nodes        => nodes_by_status(data_centers, 'DN')
     )
-  rescue BinaryNotFoundError
-    alert("Cannot find Cassandra nodetool binary")
+  rescue BinaryNotFoundError => e
+    alert("Cannot find Cassandra nodetool binary", e.message)
   rescue ConnectionError => e
     alert("Unable to connect to Cassandra", e.message)
   end
@@ -56,7 +56,7 @@ class Cassandra < Scout::Plugin
   end
 
   def nodetool_bin
-    raise BinaryNotFoundError unless File.exist?(option(:nodetool_path))
+    raise(BinaryNotFoundError, option(:nodetool_path)) unless File.exist?(option(:nodetool_path))
     @nodetool ||= option(:nodetool_path)
   end
 

--- a/cassandra/fixtures/connection_refused.txt
+++ b/cassandra/fixtures/connection_refused.txt
@@ -1,0 +1,1 @@
+Failed to connect to '127.0.0.1:7199': Connection refused

--- a/cassandra/fixtures/successful-1dc-7nodes.txt
+++ b/cassandra/fixtures/successful-1dc-7nodes.txt
@@ -1,0 +1,12 @@
+Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address     Load       Tokens       Owns (effective)  Host ID                               Rack
+UN  127.0.0.1  9.00 KB    256          29.0%             92b2d54d-dfd8-4154-a822-e45e0ca13534  rack2
+UN  127.0.0.1  10.00 KB   256          30.3%             890e7266-198b-4729-bdca-4aefe87a5f6b  rack2
+UN  127.0.0.1  11.00 KB   256          26.1%             198fc77b-8813-433a-8937-20077d0b648a  rack3
+UN  127.0.0.1  9.00 KB    256          27.0%             6727a8dc-76e5-4b5f-9409-a6866f8a6e1c  rack3
+UN  127.0.0.1  10.00 KB   256          29.9%             d750aef2-32a6-44d2-bc35-413a62dc0f46  rack2
+UN  127.0.0.1  11.00 KB   256          28.7%             55386f7c-42b2-45dd-b68c-c3eb9a0720c2  rack4
+UN  127.0.0.1  9.00 KB    256          29.0%             176ee909-414b-48eb-aecc-f04d310b64c5  rack1

--- a/cassandra/fixtures/successful-1dc-7nodes.txt
+++ b/cassandra/fixtures/successful-1dc-7nodes.txt
@@ -4,9 +4,9 @@ Status=Up/Down
 |/ State=Normal/Leaving/Joining/Moving
 --  Address     Load       Tokens       Owns (effective)  Host ID                               Rack
 UN  127.0.0.1  9.00 KB    256          29.0%             92b2d54d-dfd8-4154-a822-e45e0ca13534  rack2
-UN  127.0.0.1  10.00 KB   256          30.3%             890e7266-198b-4729-bdca-4aefe87a5f6b  rack2
-UN  127.0.0.1  11.00 KB   256          26.1%             198fc77b-8813-433a-8937-20077d0b648a  rack3
-UN  127.0.0.1  9.00 KB    256          27.0%             6727a8dc-76e5-4b5f-9409-a6866f8a6e1c  rack3
-UN  127.0.0.1  10.00 KB   256          29.9%             d750aef2-32a6-44d2-bc35-413a62dc0f46  rack2
-UN  127.0.0.1  11.00 KB   256          28.7%             55386f7c-42b2-45dd-b68c-c3eb9a0720c2  rack4
-UN  127.0.0.1  9.00 KB    256          29.0%             176ee909-414b-48eb-aecc-f04d310b64c5  rack1
+UN  127.0.0.2  10.00 KB   256          30.3%             890e7266-198b-4729-bdca-4aefe87a5f6b  rack2
+UN  127.0.0.3  11.00 KB   256          26.1%             198fc77b-8813-433a-8937-20077d0b648a  rack3
+UN  127.0.0.4  9.00 KB    256          27.0%             6727a8dc-76e5-4b5f-9409-a6866f8a6e1c  rack3
+UN  127.0.0.5  10.00 KB   256          29.9%             d750aef2-32a6-44d2-bc35-413a62dc0f46  rack2
+UN  127.0.0.6  11.00 KB   256          28.7%             55386f7c-42b2-45dd-b68c-c3eb9a0720c2  rack4
+UN  127.0.0.7  9.00 KB    256          29.0%             176ee909-414b-48eb-aecc-f04d310b64c5  rack1

--- a/cassandra/fixtures/successful-2dcs-6nodes.txt
+++ b/cassandra/fixtures/successful-2dcs-6nodes.txt
@@ -1,0 +1,17 @@
+Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address     Load       Tokens       Owns (effective)  Host ID                               Rack
+UN  127.0.0.1  5.33 GB    256          64.8%             92b2d54d-dfd8-4154-a822-e45e0ca13534  rack1
+DN  127.0.0.1  6.12 GB    256          70.1%             890e7266-198b-4729-bdca-4aefe87a5f6b  rack2
+UN  127.0.0.1  5.97 GB    256          66.2%             198fc77b-8813-433a-8937-20077d0b648a  rack3
+
+Datacenter: datacenter2
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address     Load       Tokens       Owns (effective)  Host ID                               Rack
+DN  127.0.0.1  5.41 GB    256          63.5%             6727a8dc-76e5-4b5f-9409-a6866f8a6e1c  rack1
+UN  127.0.0.1  6.27 GB    256          71.5%             d750aef2-32a6-44d2-bc35-413a62dc0f46  rack2
+UN  127.0.0.1  5.87 GB    256          67.6%             55386f7c-42b2-45dd-b68c-c3eb9a0720c2  rack3

--- a/cassandra/fixtures/successful-2dcs-6nodes.txt
+++ b/cassandra/fixtures/successful-2dcs-6nodes.txt
@@ -4,14 +4,14 @@ Status=Up/Down
 |/ State=Normal/Leaving/Joining/Moving
 --  Address     Load       Tokens       Owns (effective)  Host ID                               Rack
 UN  127.0.0.1  5.33 GB    256          64.8%             92b2d54d-dfd8-4154-a822-e45e0ca13534  rack1
-DN  127.0.0.1  6.12 GB    256          70.1%             890e7266-198b-4729-bdca-4aefe87a5f6b  rack2
-UN  127.0.0.1  5.97 GB    256          66.2%             198fc77b-8813-433a-8937-20077d0b648a  rack3
+DN  127.0.0.2  6.12 GB    256          70.1%             890e7266-198b-4729-bdca-4aefe87a5f6b  rack2
+UN  127.0.0.3  5.97 GB    256          66.2%             198fc77b-8813-433a-8937-20077d0b648a  rack3
 
 Datacenter: datacenter2
 =======================
 Status=Up/Down
 |/ State=Normal/Leaving/Joining/Moving
 --  Address     Load       Tokens       Owns (effective)  Host ID                               Rack
-DN  127.0.0.1  5.41 GB    256          63.5%             6727a8dc-76e5-4b5f-9409-a6866f8a6e1c  rack1
-UN  127.0.0.1  6.27 GB    256          71.5%             d750aef2-32a6-44d2-bc35-413a62dc0f46  rack2
-UN  127.0.0.1  5.87 GB    256          67.6%             55386f7c-42b2-45dd-b68c-c3eb9a0720c2  rack3
+DN  127.0.0.4  5.41 GB    256          63.5%             6727a8dc-76e5-4b5f-9409-a6866f8a6e1c  rack1
+UN  127.0.0.5  6.27 GB    256          71.5%             d750aef2-32a6-44d2-bc35-413a62dc0f46  rack2
+UN  127.0.0.6  5.87 GB    256          67.6%             55386f7c-42b2-45dd-b68c-c3eb9a0720c2  rack3

--- a/cassandra/test.rb
+++ b/cassandra/test.rb
@@ -5,6 +5,9 @@ class CassandraTest < Test::Unit::TestCase
 
   def setup
     @plugin = Cassandra.new(nil, {}, {:nodetool_path => "/usr/bin/nodetool"})
+    @plugin.stubs(:my_ips).returns(
+      ["127.0.0.1", "10.0.0.1"]
+    )
   end
 
   def test_successful_run_with_no_errors
@@ -46,9 +49,12 @@ class CassandraTest < Test::Unit::TestCase
     res = @plugin.run()
     assert_equal 1, res[:reports].first[:total_datacenters]
     assert_equal 7, res[:reports].first[:total_nodes]
+    assert_equal 7, res[:reports].first[:total_nodes_my_dc]
     assert_equal 10093, res[:reports].first[:avg_node_load]
-    assert_equal 7, res[:reports].first[:up_nodes]
-    assert_equal 0, res[:reports].first[:down_nodes]
+    assert_equal 7, res[:reports].first[:up_nodes_total]
+    assert_equal 0, res[:reports].first[:down_nodes_total]
+    assert_equal 7, res[:reports].first[:up_nodes_my_dc]
+    assert_equal 0, res[:reports].first[:down_nodes_my_dc]
   end
 
   def test_2_dcs_6_nodes
@@ -60,8 +66,11 @@ class CassandraTest < Test::Unit::TestCase
     res = @plugin.run()
     assert_equal 2, res[:reports].first[:total_datacenters]
     assert_equal 6, res[:reports].first[:total_nodes]
+    assert_equal 3, res[:reports].first[:total_nodes_my_dc]
     assert_equal 6258125264, res[:reports].first[:avg_node_load]
-    assert_equal 4, res[:reports].first[:up_nodes]
-    assert_equal 2, res[:reports].first[:down_nodes]
+    assert_equal 4, res[:reports].first[:up_nodes_total]
+    assert_equal 2, res[:reports].first[:down_nodes_total]
+    assert_equal 2, res[:reports].first[:up_nodes_my_dc]
+    assert_equal 1, res[:reports].first[:down_nodes_my_dc]
   end
 end

--- a/cassandra/test.rb
+++ b/cassandra/test.rb
@@ -23,6 +23,7 @@ class CassandraTest < Test::Unit::TestCase
 
     res = @plugin.run()
     assert_equal res[:alerts].first[:subject], "Cannot find Cassandra nodetool binary"
+    assert_equal res[:alerts].first[:body], "/usr/bin/nodetool"
   end
 
   def test_failed_run_with_errors

--- a/cassandra/test.rb
+++ b/cassandra/test.rb
@@ -1,0 +1,66 @@
+require File.dirname(__FILE__) + "/../test_helper.rb"
+require File.dirname(__FILE__) + "/cassandra.rb"
+
+class CassandraTest < Test::Unit::TestCase
+
+  def setup
+    @plugin = Cassandra.new(nil, {}, {:nodetool_path => "/usr/bin/nodetool"})
+  end
+
+  def test_successful_run_with_no_errors
+    @plugin.stubs(:execute_command).returns({
+      :exit_code => 0,
+      :output => File.read(File.dirname(__FILE__)+'/fixtures/successful-1dc-7nodes.txt')
+    })
+
+    res = @plugin.run()
+    assert(res[:errors].empty?, "res[:errors] is not empty")
+    assert(res[:alerts].empty?, "res[:alerts] is not empty")
+  end
+
+  def test_unable_to_find_nodetool
+    File.stubs(:exist?).with('/usr/bin/nodetool').returns(false).once
+
+    res = @plugin.run()
+    assert_equal res[:alerts].first[:subject], "Cannot find Cassandra nodetool binary"
+  end
+
+  def test_failed_run_with_errors
+    @plugin.stubs(:execute_command).returns({
+      :exit_code => 1,
+      :output => File.read(File.dirname(__FILE__)+'/fixtures/connection_refused.txt')
+    })
+
+    res = @plugin.run()
+    assert_equal res[:alerts].first[:subject], "Unable to connect to Cassandra"
+    assert_equal res[:alerts].first[:body], "Failed to connect to '127.0.0.1:7199': Connection refused"
+  end
+
+  def test_1_dc_7_nodes
+    @plugin.stubs(:execute_command).returns({
+      :exit_code => 0,
+      :output => File.read(File.dirname(__FILE__)+'/fixtures/successful-1dc-7nodes.txt')
+    })
+
+    res = @plugin.run()
+    assert_equal 1, res[:reports].first[:total_datacenters]
+    assert_equal 7, res[:reports].first[:total_nodes]
+    assert_equal 10093, res[:reports].first[:avg_node_load]
+    assert_equal 7, res[:reports].first[:up_nodes]
+    assert_equal 0, res[:reports].first[:down_nodes]
+  end
+
+  def test_2_dcs_6_nodes
+    @plugin.stubs(:execute_command).returns({
+      :exit_code => 0,
+      :output => File.read(File.dirname(__FILE__)+'/fixtures/successful-2dcs-6nodes.txt')
+    })
+
+    res = @plugin.run()
+    assert_equal 2, res[:reports].first[:total_datacenters]
+    assert_equal 6, res[:reports].first[:total_nodes]
+    assert_equal 6258125264, res[:reports].first[:avg_node_load]
+    assert_equal 4, res[:reports].first[:up_nodes]
+    assert_equal 2, res[:reports].first[:down_nodes]
+  end
+end


### PR DESCRIPTION
This is a plugin to monitor [Cassandra](http://cassandra.apache.org) cluster health.  I've tested it with Cassandra versions 2.1 and 3.x.  The default value for `nodetool_path` is for the DEB package install and is probably the same for RPM install, but will be different for tarball installs.