### PR TITLE
added reporting of old gen used space percentage

### DIFF
--- a/elasticsearch_node_status/elasticsearch_node_status.rb
+++ b/elasticsearch_node_status/elasticsearch_node_status.rb
@@ -56,6 +56,7 @@ class ElasticsearchClusterNodeStatus < Scout::Plugin
     report(:size_of_indices => b_to_mb(mem) || 0)
     report(:num_docs => (response['indices']['docs']['count'] rescue 0))
     report(:open_file_descriptors => response['process']['open_file_descriptors'] || 0)
+    report(:old_gen_heap_percent_used => (response['jvm']['mem']['pools']['old']['used_in_bytes'].to_f / response['jvm']['mem']['pools']['old']['max_in_bytes']) * 100)
     report(:heap_used => b_to_mb(response['jvm']['mem']['heap_used_in_bytes'] || 0))
     report(:heap_committed => b_to_mb(response['jvm']['mem']['heap_committed_in_bytes'] || 0))
     report(:non_heap_used => b_to_mb(response['jvm']['mem']['non_heap_used_in_bytes'] || 0))


### PR DESCRIPTION
This commit adds a report of the active old gen space via percentage.  The plugin previously only reported on total heap usage and old gen collection times.